### PR TITLE
Merge Comment count on untranslated archives

### DIFF
--- a/multilingual-comments-wpml.php
+++ b/multilingual-comments-wpml.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Multilingual Comments WPML
  * Plugin URI: https://wordpress.org/plugins/multilingual-comments-wpml
- * Description: VERSIONE MODIFICATA PER ENROMA, NON AGGIORNARE! Merge comments from all WPML translations of a post.
+ * Description: This plugin combines comments from all translations of the posts and pages using WPML. Comments are internally still attached to the post or page in the language they were made on.
  *
  * Version: 1.2.1
  * Author: Pieter Bos


### PR DESCRIPTION
If you show the comment count in taxonomy archives, and the taxonomy you're on is not translated, the comments were not merged because WPML gets no other languages on that archive.

I changed the merge_comment_count method to loop, not WPML languages, but get the translation group of the post and loop through them then: if the translated post is published and the language is not between hidden languages then merge.